### PR TITLE
fix: github pages does not support client-side routing

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Diff Viewer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { BrowserRouter, Routes, Route } from 'react-router';
 import { Layout } from "./components/layout";
 import { TextDiff } from "./pages";
 import { useDynamicFavicon } from "./hooks/useDynamicFavicon";
-import { ComingSoon } from './components/ui';
+import { ComingSoon, NotFound } from './components/ui';
 
 function App() {
   useDynamicFavicon();
@@ -13,6 +13,7 @@ function App() {
         <Routes>
           <Route path="/" element={<TextDiff />} />
           <Route path="/image" element={<ComingSoon />} />
+          <Route path="*" element={<NotFound />} />
         </Routes>
       </Layout>
     </BrowserRouter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from 'react-router';
 import { Layout } from "./components/layout";
 import { TextDiff } from "./pages";
 import { useDynamicFavicon } from "./hooks/useDynamicFavicon";
+import { ComingSoon } from './components/ui';
 
 function App() {
   useDynamicFavicon();
@@ -11,6 +12,7 @@ function App() {
       <Layout>
         <Routes>
           <Route path="/" element={<TextDiff />} />
+          <Route path="/image" element={<ComingSoon />} />
         </Routes>
       </Layout>
     </BrowserRouter>

--- a/src/components/ui/ComingSoon.tsx
+++ b/src/components/ui/ComingSoon.tsx
@@ -1,0 +1,31 @@
+import { Loading } from "./Loading";
+
+interface ComingSoonProps {
+  title?: string;
+  description?: string;
+  className?: string;
+}
+
+export const ComingSoon = ({ 
+  title = "Coming Soon", 
+  description = "This feature is under development and will be available soon.",
+  className = "" 
+}: ComingSoonProps) => {
+  return (
+    <div className={`flex-1 flex items-center justify-center bg-white dark:bg-gray-800 rounded-md shadow-lg ${className}`}>
+      <div className="text-center p-12 max-w-md">
+        <h2 className="text-2xl font-semibold text-gray-800 dark:text-gray-200 mb-3">
+          {title}
+        </h2>
+        
+        <p className="text-gray-600 dark:text-gray-400 leading-relaxed">
+          {description}
+        </p>
+        
+        <div className="mt-6 flex justify-center">
+          <Loading />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/Loading.tsx
+++ b/src/components/ui/Loading.tsx
@@ -1,0 +1,15 @@
+export const Loading = () => {
+  return (
+    <div className="flex space-x-1">
+      <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse"></div>
+      <div
+        className="w-2 h-2 bg-blue-500 rounded-full animate-pulse"
+        style={{ animationDelay: "0.2s" }}
+      ></div>
+      <div
+        className="w-2 h-2 bg-blue-500 rounded-full animate-pulse"
+        style={{ animationDelay: "0.4s" }}
+      ></div>
+    </div>
+  );
+};

--- a/src/components/ui/NotFound.tsx
+++ b/src/components/ui/NotFound.tsx
@@ -1,0 +1,99 @@
+import { useNavigate } from "react-router";
+
+export const NotFound = () => {
+  const navigate = useNavigate();
+
+  const handleGoHome = () => {
+    navigate("/");
+  };
+
+  const handleGoBack = () => {
+    navigate(-1);
+  };
+
+  return (
+    <div className="flex-1 flex items-center justify-center bg-white dark:bg-gray-800 rounded-md shadow-lg">
+      <div className="flex-1 p-3 sm:p-4 md:p-6 text-center max-w-lg">
+        {/* 404 Number */}
+        <div className="mb-4 sm:mb-6">
+          <h1 className="text-6xl sm:text-7xl md:text-8xl lg:text-9xl font-bold text-gray-200 dark:text-gray-700 select-none">
+            404
+          </h1>
+        </div>
+
+        {/* Title and Description */}
+        <h2 className="text-xl sm:text-2xl md:text-3xl font-bold text-gray-800 dark:text-gray-200 mb-3 sm:mb-4">
+          Page Not Found
+        </h2>
+
+        <p className="text-gray-600 dark:text-gray-400 mb-6 sm:mb-8 leading-relaxed text-sm sm:text-base">
+          Sorry, the page you are looking for doesn't exist or has been moved.
+        </p>
+
+        {/* Action Buttons */}
+        <div className="flex flex-col sm:flex-row gap-3 justify-center max-w-xs sm:max-w-none mx-auto">
+          <button
+            onClick={handleGoHome}
+            className="flex-1 sm:flex-none px-4 py-2.5 sm:px-6 sm:py-3 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-medium rounded-lg transition-colors duration-200 flex items-center justify-center gap-2 cursor-pointer touch-manipulation min-h-[44px] sm:min-h-[48px]"
+          >
+            <svg
+              className="w-4 h-4 flex-shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+              />
+            </svg>
+            <span className="text-sm sm:text-base">Go Home</span>
+          </button>
+
+          <button
+            onClick={handleGoBack}
+            className="flex-1 sm:flex-none px-4 py-2.5 sm:px-6 sm:py-3 bg-gray-500 hover:bg-gray-600 active:bg-gray-700 text-white font-medium rounded-lg transition-colors duration-200 flex items-center justify-center gap-2 cursor-pointer touch-manipulation min-h-[44px] sm:min-h-[48px]"
+          >
+            <svg
+              className="w-4 h-4 flex-shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 19l-7-7m0 0l7-7m-7 7h18"
+              />
+            </svg>
+            <span className="text-sm sm:text-base">Go Back</span>
+          </button>
+        </div>
+
+        {/* Helpful Links */}
+        <div className="mt-4 sm:mt-6 md:mt-8 pt-3 sm:pt-4 md:pt-6 border-t border-gray-200 dark:border-gray-700">
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-2 sm:mb-3">
+            Available pages:
+          </p>
+          <div className="flex flex-wrap justify-center gap-3 sm:gap-4 text-sm">
+            <button
+              onClick={() => navigate("/")}
+              className="text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
+            >
+              Text Diff
+            </button>
+            <button
+              onClick={() => navigate("/image")}
+              className="text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
+            >
+              Image Diff
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -1,3 +1,5 @@
 export * from './Logo';
 export * from './NavigationLink';
 export * from './Divider';
+export * from './ComingSoon';
+export * from './Loading';

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -3,3 +3,4 @@ export * from './NavigationLink';
 export * from './Divider';
 export * from './ComingSoon';
 export * from './Loading';
+export * from './NotFound';


### PR DESCRIPTION
GitHub Pages does not support client-side routing by default. Whe reload a child route, the server looks for a corresponding file or directory, which doesn't exist.

closes: #6 